### PR TITLE
fix: empty bulk string handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ coverage/
 cov.lcov
 deno.lock
 html_cov/
+.env

--- a/mod.ts
+++ b/mod.ts
@@ -140,16 +140,8 @@ async function readReply(
     case BOOLEAN_PREFIX:
       return parseLine(value) === "t";
     case BULK_STRING_PREFIX:
-    case VERBATIM_STRING_PREFIX: {
-      switch (parseLine(value)) {
-        case "-1":
-          return null;
-        case "0":
-          return raw ? new Uint8Array() : "";
-        default:
-          return readReply(iterator, raw);
-      }
-    }
+    case VERBATIM_STRING_PREFIX:
+      return parseLine(value) === "-1" ? null : readReply(iterator, raw);
     case DOUBLE_PREFIX:
     case INTEGER_PREFIX: {
       switch (parseLine(value)) {

--- a/test.ts
+++ b/test.ts
@@ -80,63 +80,9 @@ Deno.test("readReply() - bulk string containing CRLF (known issue)", () =>
   readReplyTest("$7\r\nhello\r\n\r\n", "hello"));
 
 Deno.test("readReply() - emtpy bulk string", () =>
-  readReplyTest("$0\r\n\r\n", ""));
-
-Deno.test("readReply() - empty bulk string 2", () =>
   readReplyTest(
-    `%2
-+id
-$9
-movie:381
-+extra_attributes
-%8
-$4
-plot
-$0
-
-$8
-ibmdb_id
-$9
-tt0099698
-$12
-release_year
-$4
-1990
-$6
-rating
-$3
-8.1
-$5
-title
-$18
-The Gravy Train ()
-$5
-genre
-$6
-Comedy
-$6
-poster
-$130
-https://m.media-amazon.com/images/M/MV5BMDBlZjZkOTQtNzU5YS00OTk1LTg2MGUtMGY5ZGZhNDBmMGMyXkEyXkFqcGdeQXVyMzY2ODUzMjA@._V1_SX300.jpg
-$5
-votes
-$2
-71
-`.replaceAll("\n", "\r\n"),
-    {
-      id: "movie:381",
-      extra_attributes: {
-        votes: "71",
-        rating: "8.1",
-        plot: "",
-        ibmdb_id: "tt0099698",
-        release_year: "1990",
-        title: "The Gravy Train ()",
-        genre: "Comedy",
-        poster:
-          "https://m.media-amazon.com/images/M/MV5BMDBlZjZkOTQtNzU5YS00OTk1LTg2MGUtMGY5ZGZhNDBmMGMyXkEyXkFqcGdeQXVyMzY2ODUzMjA@._V1_SX300.jpg",
-      },
-    },
+    "%2\r\n$5\r\nempty\r\n$0\r\n\r\n$3\r\nfoo\r\n$3\r\nbar\r\n",
+    { empty: "", foo: "bar" },
   ));
 
 Deno.test("readReply() - emtpy raw bulk string", () =>

--- a/test.ts
+++ b/test.ts
@@ -82,6 +82,63 @@ Deno.test("readReply() - bulk string containing CRLF (known issue)", () =>
 Deno.test("readReply() - emtpy bulk string", () =>
   readReplyTest("$0\r\n\r\n", ""));
 
+Deno.test("readReply() - empty bulk string 2", () =>
+  readReplyTest(
+    `%2
++id
+$9
+movie:381
++extra_attributes
+%8
+$4
+plot
+$0
+
+$8
+ibmdb_id
+$9
+tt0099698
+$12
+release_year
+$4
+1990
+$6
+rating
+$3
+8.1
+$5
+title
+$18
+The Gravy Train ()
+$5
+genre
+$6
+Comedy
+$6
+poster
+$130
+https://m.media-amazon.com/images/M/MV5BMDBlZjZkOTQtNzU5YS00OTk1LTg2MGUtMGY5ZGZhNDBmMGMyXkEyXkFqcGdeQXVyMzY2ODUzMjA@._V1_SX300.jpg
+$5
+votes
+$2
+71
+`.replaceAll("\n", "\r\n"),
+    {
+      id: "movie:381",
+      extra_attributes: {
+        votes: "71",
+        rating: "8.1",
+        plot: "",
+        ibmdb_id: "tt0099698",
+        release_year: "1990",
+        title: "The Gravy Train ()",
+        genre: "Comedy",
+        poster:
+          "https://m.media-amazon.com/images/M/MV5BMDBlZjZkOTQtNzU5YS00OTk1LTg2MGUtMGY5ZGZhNDBmMGMyXkEyXkFqcGdeQXVyMzY2ODUzMjA@._V1_SX300.jpg",
+      },
+    },
+  ));
+
 Deno.test("readReply() - emtpy raw bulk string", () =>
   readReplyTest("$0\r\n\r\n", new Uint8Array(), true));
 


### PR DESCRIPTION
While creating the demo, I ran into a case where an empty bulk string isn't handled correctly. This is because the parse returns an empty string, but skips the reading of the empty string line. This leaves the line iterator one line behind where it should be.