### PR TITLE
chore: use `const` instead of `using` in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ all major JavaScript runtimes. Built upon the
 import { RedisClient } from "@iuioiua/redis";
 import { assertEquals } from "@std/assert/equals";
 
-using redisConn = await Deno.connect({ port: 6379 });
+const redisConn = await Deno.connect({ port: 6379 });
 const redisClient = new RedisClient(redisConn);
 
 const reply1 = await redisClient.sendCommand(["SET", "hello", "world"]);
@@ -70,4 +70,4 @@ footprint than other JavaScript implementations of Redis clients.
 | npm:ioredis        | 894.69    | 10           |
 | npm:redis          | 951.12    | 9            |
 
-> Note: Results were produced using `deno info <module>` on March 9, 2025.
+> Note: Results were produced const `deno info <module>` on March 9, 2025.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Lightning-fast, lightweight and reliable [Redis](https://redis.io/) client for
 all major JavaScript runtimes. Built upon the
 [Streams API](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API).
 
-```ts
+```ts ignore
 import { RedisClient } from "@iuioiua/redis";
 import { assertEquals } from "@std/assert/equals";
 

--- a/mod.ts
+++ b/mod.ts
@@ -9,7 +9,7 @@ import { concat } from "@std/bytes/concat";
  * import { RedisClient } from "@iuioiua/redis";
  * import { assertEquals } from "@std/assert/equals";
  *
- * using redisConn = await Deno.connect({ port: 6379 });
+ * const redisConn = await Deno.connect({ port: 6379 });
  * const redisClient = new RedisClient(redisConn);
  *
  * const reply1 = await redisClient.sendCommand(["SET", "hello", "world"]);
@@ -183,7 +183,7 @@ async function readReply(
  * import { RedisClient } from "@iuioiua/redis";
  * import { assertEquals } from "@std/assert/equals";
  *
- * using redisConn = await Deno.connect({ port: 6379 });
+ * const redisConn = await Deno.connect({ port: 6379 });
  * const redisClient = new RedisClient(redisConn);
  *
  * const reply1 = await redisClient.sendCommand(["SET", "hello", "world"]);
@@ -204,7 +204,7 @@ async function readReply(
  * import { RedisClient } from "@iuioiua/redis";
  * import { assertEquals } from "@std/assert/equals";
  *
- * using redisConn = await Deno.connect({ port: 6379 });
+ * const redisConn = await Deno.connect({ port: 6379 });
  * const redisClient = new RedisClient(redisConn);
  *
  * // Switch to RESP3
@@ -226,7 +226,7 @@ async function readReply(
  * import { RedisClient } from "@iuioiua/redis";
  * import { assertEquals } from "@std/assert/equals";
  *
- * using redisConn = await Deno.connect({ port: 6379 });
+ * const redisConn = await Deno.connect({ port: 6379 });
  * const redisClient = new RedisClient(redisConn);
  *
  * const data = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
@@ -248,7 +248,7 @@ async function readReply(
  * import { RedisClient } from "@iuioiua/redis";
  * import { deadline } from "jsr:@std/async/deadline";
  *
- * using redisConn = await Deno.connect({ port: 6379 });
+ * const redisConn = await Deno.connect({ port: 6379 });
  * const redisClient = new RedisClient(redisConn);
  *
  * // Rejects with a timeout error if the command takes longer than 100 milliseconds.
@@ -265,10 +265,10 @@ async function readReply(
  * import { RedisClient } from "@iuioiua/redis";
  * import { retry } from "jsr:@std/async/retry";
  *
- * using redisConn = await Deno.connect({ port: 6379 });
+ * const redisConn = await Deno.connect({ port: 6379 });
  * const redisClient = new RedisClient(redisConn);
  *
- * // Retries to connect until successful using the exponential backoff algorithm.
+ * // Retries to connect until successful const the exponential backoff algorithm.
  * await retry(() => redisClient.sendCommand(["GET", "foo"]));
  * ```
  *
@@ -282,7 +282,7 @@ async function readReply(
  * import { RedisClient } from "@iuioiua/redis";
  * import { assertEquals } from "@std/assert/equals";
  *
- * using redisConn = await Deno.connect({ port: 6379 });
+ * const redisConn = await Deno.connect({ port: 6379 });
  * const redisClient = new RedisClient(redisConn);
  *
  * const replies = await redisClient.pipelineCommands([
@@ -304,7 +304,7 @@ async function readReply(
  * import { RedisClient } from "@iuioiua/redis";
  * import { assertEquals } from "@std/assert/equals";
  *
- * using redisConn = await Deno.connect({ port: 6379 });
+ * const redisConn = await Deno.connect({ port: 6379 });
  * const redisClient = new RedisClient(redisConn);
  *
  * await redisClient.writeCommand(["SUBSCRIBE", "mychannel"]);
@@ -324,7 +324,7 @@ async function readReply(
  * import { RedisClient } from "@iuioiua/redis";
  * import { assertEquals } from "@std/assert/equals";
  *
- * using redisConn = await Deno.connect({ port: 6379 });
+ * const redisConn = await Deno.connect({ port: 6379 });
  * const redisClient = new RedisClient(redisConn);
  *
  * assertEquals(await redisClient.sendCommand(["MULTI"]), "OK");
@@ -343,7 +343,7 @@ async function readReply(
  * import { RedisClient } from "@iuioiua/redis";
  * import { assertEquals } from "@std/assert/equals";
  *
- * using redisConn = await Deno.connect({ port: 6379 });
+ * const redisConn = await Deno.connect({ port: 6379 });
  * const redisClient = new RedisClient(redisConn);
  *
  * const reply1 = await redisClient.sendCommand(["EVAL", "return ARGV[1]", 0, "hello"]);
@@ -389,7 +389,7 @@ export class RedisClient {
    * import { RedisClient } from "@iuioiua/redis";
    * import { assertEquals } from "@std/assert/equals";
    *
-   * using redisConn = await Deno.connect({ port: 6379 });
+   * const redisConn = await Deno.connect({ port: 6379 });
    * const redisClient = new RedisClient(redisConn);
    *
    * const reply1 = await redisClient.sendCommand(["SET", "hello", "world"]);
@@ -414,7 +414,7 @@ export class RedisClient {
    * import { RedisClient } from "@iuioiua/redis";
    * import { assertEquals } from "@std/assert/equals";
    *
-   * using redisConn = await Deno.connect({ port: 6379 });
+   * const redisConn = await Deno.connect({ port: 6379 });
    * const redisClient = new RedisClient(redisConn);
    *
    * await redisClient.writeCommand(["SUBSCRIBE", "mychannel"]);
@@ -441,7 +441,7 @@ export class RedisClient {
    * import { RedisClient } from "@iuioiua/redis";
    * import { assertEquals } from "@std/assert/equals";
    *
-   * using redisConn = await Deno.connect({ port: 6379 });
+   * const redisConn = await Deno.connect({ port: 6379 });
    * const redisClient = new RedisClient(redisConn);
    *
    * await redisClient.writeCommand(["SUBSCRIBE", "mychannel"]);
@@ -471,7 +471,7 @@ export class RedisClient {
    * import { RedisClient } from "@iuioiua/redis";
    * import { assertEquals } from "@std/assert/equals";
    *
-   * using redisConn = await Deno.connect({ port: 6379 });
+   * const redisConn = await Deno.connect({ port: 6379 });
    * const redisClient = new RedisClient(redisConn);
    *
    * const replies = await redisClient.pipelineCommands([


### PR DESCRIPTION
Just because of syntax highlighting